### PR TITLE
Adds Support for Ember-beta version and Upgrades Ember

### DIFF
--- a/addon/initializers/add-data-test-to-view.js
+++ b/addon/initializers/add-data-test-to-view.js
@@ -60,16 +60,13 @@ export default {
     const dasherizeAttr = this._buildDasherizedAttr(dataTestSuffix);
     const camelizeAttr = camelize(dasherizeAttr);
 
-    const attributeBindingsLabel = `${camelizeAttr}:${dasherizeAttr}`;
+    const attrBindingsLabels = [`${camelizeAttr}:${dasherizeAttr}`];
     attrs.init = function() {
       this._super(...arguments);
       if (this.get('tagName') !== '') {
-        const attributeBindings = get(this, 'attributeBindings');
-        if (attributeBindings) {
-          attributeBindings.push(attributeBindingsLabel);
-        } else {
-          set(this, 'attributeBindings', [attributeBindingsLabel]);
-        }
+        const oldAttrBindings = get(this, 'attributeBindings') || [];
+        const newAttrBindings = attrBindingsLabels.concat(oldAttrBindings);
+        set(this, 'attributeBindings', newAttrBindings);
       }
     };
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-data-test-id",
   "dependencies": {
-    "ember": "~2.7.0",
+    "ember": "~2.10.2",
     "ember-cli-shims": "0.1.1",
     "ember-qunit-notifications": "0.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",
-    "ember-cli": "2.7.0",
+    "ember-cli": "2.10.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-fastboot": "1.0.0-beta.7",
@@ -33,7 +33,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0",
+    "ember-data": "^2.10.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",


### PR DESCRIPTION
This changes logic for newly frozen attributeBindings that happens in ember `2.11.beta.1`.  It also updates the version of ember used to 2.10.0.